### PR TITLE
fixed bug in hook_modify

### DIFF
--- a/manifold_mixup.py
+++ b/manifold_mixup.py
@@ -65,12 +65,13 @@ class ManifoldMixupModel(nn.Module):
         return out, self.lam
 
     def hook_modify(self, module, input, output):
-        if not self.hooked:
+        if not self._hooked:
             output = (1 - self.lam) * self.intermediate_other + self.lam * output
             self._update_hooked(True)
+            return output
 
     def hook_fetch(self, module, input, output):
-        if not self.hooked:
+        if not self._hooked:
             self.intermediate_other = output
             self._update_hooked(True)
         else:
@@ -80,7 +81,7 @@ class ManifoldMixupModel(nn.Module):
                 self._warning_raised = True
     
     def _update_hooked(self, flag):
-        self.hooked = flag
+        self._hooked = flag
 
 
 class ManifoldMixupLoss(nn.Module):


### PR DESCRIPTION
While using your code as a basis for a fastai version of manifold mixup, I found a bug in `hook_modify`.

You had no `return` meaning that the output was not modified and that only the target output was perturbed when you were not applying mixup to the input (which, by itself, has some regularizing properties).

I also switched all `self.hooked` to `self._hooked` as you used both notations (probably a typo).